### PR TITLE
Add defaultTab as option

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = async ({ markdownAST }, options = { width: 600, height: 300 }) 
       node.value = `<div><iframe 
         height='${options.height}' 
         scrolling='no' 
-        src='//codepen.io/${penUser}/embed/preview/${penId}/?height=${options.height}&theme-id=${options.theme}&default-tab=html,result' 
+        src='//codepen.io/${penUser}/embed/preview/${penId}/?height=${options.height}&theme-id=${options.theme}&default-tab=${options.defaultTab || 'html,result'}' 
         frameborder='no' 
         allowtransparency='true' 
         allowfullscreen='true' 


### PR DESCRIPTION
with `options.defaultTab` you can set a string like `"html,css"` to set a different defaultTab. If value is omitted, it falls back to `"html, result"`.